### PR TITLE
Fix link to examples in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ http get with retry:
 
     fmt.Println(body)
 
-[next examples](https://github.com/avast/retry-go/examples)
+[next examples](https://github.com/avast/retry-go/tree/master/examples)
 
 
 ### SEE ALSO

--- a/retry.go
+++ b/retry.go
@@ -28,7 +28,7 @@ http get with retry:
 
 	fmt.Println(body)
 
-[next examples](https://github.com/avast/retry-go/examples)
+[next examples](https://github.com/avast/retry-go/tree/master/examples)
 
 
 SEE ALSO


### PR DESCRIPTION
Just fixes a small mistake in the readme and synopsis comments.