### PR TITLE
Return immediately if error occur in the last retry attempt (don’t wait)

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -94,6 +94,11 @@ func Do(retryableFunc RetryableFunc, opts ...Option) error {
 				break
 			}
 
+			// if this is last attempt - don't wait
+			if n == config.attempts-1 {
+				break
+			}
+
 			delayTime := config.delay * (1 << (n - 1))
 			time.Sleep((time.Duration)(delayTime) * config.units)
 		} else {


### PR DESCRIPTION
At the current implementation after **last** retry (it will be no mo retries!) **fails** - we're waiting **additional time** before returning:
```
...
delayTime := config.delay * (1 << (n - 1))
time.Sleep((time.Duration)(delayTime) * config.units)
```

For example (5 attempts, 1 sec delay) we'll wait 1 sec * 2 ^ 4 = **16 sec**! before return error (despite we already know that err should be returned)
 
**I've added check to return without wait.**

