### PR TITLE
Allow to configure fixed or back off delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,32 @@ now implement via functions produces Options (aka `retry.OnRetry`)
 
 ## Usage
 
+#### func  BackOffDelay
+
+```go
+func BackOffDelay(n uint, config *config) time.Duration
+```
+BackOffDelay is a DelayType which increases delay between consecutive retries
+
 #### func  Do
 
 ```go
 func Do(retryableFunc RetryableFunc, opts ...Option) error
 ```
+
+#### func  FixedDelay
+
+```go
+func FixedDelay(_ uint, config *config) time.Duration
+```
+FixedDelay is a DelayType which keeps delay the same through all iterations
+
+#### type DelayTypeFunc
+
+```go
+type DelayTypeFunc func(n uint, config *config) time.Duration
+```
+
 
 #### type Error
 
@@ -143,6 +164,13 @@ Attempts set count of retry default is 10
 func Delay(delay time.Duration) Option
 ```
 Delay set delay between retry default is 100ms
+
+#### func  DelayType
+
+```go
+func DelayType(delayType DelayTypeFunc) Option
+```
+DelayType set type of the delay between retries default is BackOff
 
 #### func  OnRetry
 

--- a/retry.go
+++ b/retry.go
@@ -78,10 +78,11 @@ func Do(retryableFunc RetryableFunc, opts ...Option) error {
 
 	//default
 	config := &config{
-		attempts: 10,
-		delay:    100 * time.Millisecond,
-		onRetry:  func(n uint, err error) {},
-		retryIf:  func(err error) bool { return true },
+		attempts:  10,
+		delay:     100 * time.Millisecond,
+		onRetry:   func(n uint, err error) {},
+		retryIf:   func(err error) bool { return true },
+		delayType: BackOffDelay,
 	}
 
 	//apply opts
@@ -107,7 +108,7 @@ func Do(retryableFunc RetryableFunc, opts ...Option) error {
 				break
 			}
 
-			delayTime := config.delay * (1 << (n - 1))
+			delayTime := config.delayType(n, config)
 			time.Sleep(delayTime)
 		} else {
 			return nil

--- a/retry_test.go
+++ b/retry_test.go
@@ -80,3 +80,15 @@ func TestDefaultSleep(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, dur > 10*time.Millisecond, "3 times default retry is longer then 10ms")
 }
+
+func TestFixedSleep(t *testing.T) {
+	start := time.Now()
+	err := Do(
+		func() error { return errors.New("test") },
+		Attempts(3),
+		DelayType(FixedDelay),
+	)
+	dur := time.Since(start)
+	assert.Error(t, err)
+	assert.True(t, dur < 500*time.Millisecond, "3 times default retry is shorter then 500ms")
+}


### PR DESCRIPTION
This PR adds additional `Option`: `DelayType`. It allows to switch between different delay calculation algorithms. There are two for now: `FixedDelay` which takes the same delay value every iteration, and BackOffDelay which works as previously. BackOffDelay is default.