### PR TITLE
Fix missing delay before second attempt

### DIFF
--- a/options.go
+++ b/options.go
@@ -59,7 +59,7 @@ func DelayType(delayType DelayTypeFunc) Option {
 
 // BackOffDelay is a DelayType which increases delay between consecutive retries
 func BackOffDelay(n uint, config *Config) time.Duration {
-	return config.delay * (1 << (n - 1))
+	return config.delay * (1 << n)
 }
 
 // FixedDelay is a DelayType which keeps delay the same through all iterations

--- a/retry_test.go
+++ b/retry_test.go
@@ -80,7 +80,7 @@ func TestDefaultSleep(t *testing.T) {
 	)
 	dur := time.Since(start)
 	assert.Error(t, err)
-	assert.True(t, dur > 10*time.Millisecond, "3 times default retry is longer then 10ms")
+	assert.True(t, dur > 300*time.Millisecond, "3 times default retry is longer then 300ms")
 }
 
 func TestFixedSleep(t *testing.T) {


### PR DESCRIPTION
As pointed in #17 there is a missing delay before the second attempt. Not sure if it is on purpose, but in case it's not here's the fix.