### PR TITLE
retryIf should be called before onRetry

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -97,12 +97,13 @@ func Do(retryableFunc RetryableFunc, opts ...Option) error {
 		err := retryableFunc()
 
 		if err != nil {
-			config.onRetry(n, err)
 			errorLog[n] = unpackUnrecoverable(err)
 
 			if !config.retryIf(err) {
 				break
 			}
+
+			config.onRetry(n, err)
 
 			// if this is last attempt - don't wait
 			if n == config.attempts-1 {

--- a/retry_test.go
+++ b/retry_test.go
@@ -68,7 +68,7 @@ func TestRetryIf(t *testing.T) {
 #2: test
 #3: special`
 	assert.Equal(t, expectedErrorFormat, err.Error(), "retry error format")
-	assert.Equal(t, uint(3), retryCount, "right count of retry")
+	assert.Equal(t, uint(2), retryCount, "right count of retry")
 
 }
 
@@ -103,6 +103,7 @@ func TestLastErrorOnly(t *testing.T) {
 		Delay(time.Nanosecond),
 		LastErrorOnly(true),
 	)
+	assert.Error(t, err)
 	assert.Equal(t, "9", err.Error())
 }
 


### PR DESCRIPTION
- The `func onRetry` is called before checking if the `retryableFunc` should be retried. The `func retryIf`, called after `onRetry`, tells whether the retry should be performed or not. `retryIf` should be called before `onRetry`.
- fixes #20