### PR TITLE
Support random jitter combined with other delay options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,17 @@ func IsRecoverable(err error) bool
 ```
 IsRecoverable checks if error is an instance of `unrecoverableError`
 
+#### func  RandomDelay
+
+```go
+func RandomDelay(_ uint, config *Config) time.Duration
+```
+RandomDelay is a DelayType which picks a random delay up to config.maxJitter
+
 #### func  Unrecoverable
 
 ```go
-func Unrecoverable(err error) unrecoverableError
+func Unrecoverable(err error) error
 ```
 Unrecoverable wraps an error in `unrecoverableError` struct
 
@@ -130,6 +137,14 @@ type Config struct {
 type DelayTypeFunc func(n uint, config *Config) time.Duration
 ```
 
+
+#### func  CombineDelay
+
+```go
+func CombineDelay(delays ...DelayTypeFunc) DelayTypeFunc
+```
+CombineDelay is a DelayType the combines all of the specified delays into a new
+DelayTypeFunc
 
 #### type Error
 
@@ -202,6 +217,13 @@ func LastErrorOnly(lastErrorOnly bool) Option
 return the direct last error that came from the retried function default is
 false (return wrapped errors with everything)
 
+#### func  MaxJitter
+
+```go
+func MaxJitter(maxJitter time.Duration) Option
+```
+MaxJitter sets the maximum random Jitter between retries for RandomDelay
+
 #### func  OnRetry
 
 ```go
@@ -242,7 +264,7 @@ skip retry if special error example:
     	})
     )
 
-The default RetryIf stops execution if the error is wrapped using
+By default RetryIf stops execution if the error is wrapped using
 `retry.Unrecoverable`, so above example may also be shortened to:
 
     retry.Do(

--- a/retry.go
+++ b/retry.go
@@ -80,9 +80,10 @@ func Do(retryableFunc RetryableFunc, opts ...Option) error {
 	config := &Config{
 		attempts:      10,
 		delay:         100 * time.Millisecond,
+		maxJitter:     100 * time.Millisecond,
 		onRetry:       func(n uint, err error) {},
 		retryIf:       IsRecoverable,
-		delayType:     BackOffDelay,
+		delayType:     CombineDelay(BackOffDelay, RandomDelay),
 		lastErrorOnly: false,
 	}
 

--- a/retry_test.go
+++ b/retry_test.go
@@ -121,3 +121,30 @@ func TestUnrecoverableError(t *testing.T) {
 	assert.Equal(t, expectedErr, err)
 	assert.Equal(t, 1, attempts, "unrecoverable error broke the loop")
 }
+
+func TestCombineFixedDelays(t *testing.T) {
+	start := time.Now()
+	err := Do(
+		func() error { return errors.New("test") },
+		Attempts(3),
+		DelayType(CombineDelay(FixedDelay, FixedDelay)),
+	)
+	dur := time.Since(start)
+	assert.Error(t, err)
+	assert.True(t, dur > 400*time.Millisecond, "3 times combined, fixed retry is longer then 400ms")
+	assert.True(t, dur < 500*time.Millisecond, "3 times combined, fixed retry is shorter then 500ms")
+}
+
+func TestRandomDelay(t *testing.T) {
+	start := time.Now()
+	err := Do(
+		func() error { return errors.New("test") },
+		Attempts(3),
+		DelayType(RandomDelay),
+		MaxJitter(50 * time.Millisecond),
+	)
+	dur := time.Since(start)
+	assert.Error(t, err)
+	assert.True(t, dur > 2*time.Millisecond, "3 times random retry is longer then 2ms")
+	assert.True(t, dur < 100*time.Millisecond, "3 times random retry is shorter then 100ms")
+}


### PR DESCRIPTION
Issue #9 initially proposed having a random jitter component to the delay; however, PR #12 omitted the random jitter.  This PR adds both a `RandomDelay` (for jitter) and `CombineDelay` (to allow combining any number of delays).  In addition, the default delay changes from exponential backoff (`BackOffDelay`) to exponential backoff with random jitter (`BackOffDelay` & `RandomDelay`).