### PR TITLE
Add a MaxDelay option

### DIFF
--- a/options.go
+++ b/options.go
@@ -17,6 +17,7 @@ type DelayTypeFunc func(n uint, config *Config) time.Duration
 type Config struct {
 	attempts      uint
 	delay         time.Duration
+	maxDelay      time.Duration
 	maxJitter     time.Duration
 	onRetry       OnRetryFunc
 	retryIf       RetryIfFunc
@@ -48,6 +49,14 @@ func Attempts(attempts uint) Option {
 func Delay(delay time.Duration) Option {
 	return func(c *Config) {
 		c.delay = delay
+	}
+}
+
+// MaxDelay set maximum delay between retry
+// does not apply by default
+func MaxDelay(maxDelay time.Duration) Option {
+	return func(c *Config) {
+		c.maxDelay = maxDelay
 	}
 }
 

--- a/retry.go
+++ b/retry.go
@@ -118,6 +118,9 @@ func Do(retryableFunc RetryableFunc, opts ...Option) error {
 			}
 
 			delayTime := config.delayType(n, config)
+			if config.maxDelay > 0 && delayTime > config.maxDelay {
+				delayTime = config.maxDelay
+			}
 			time.Sleep(delayTime)
 		} else {
 			return nil

--- a/retry_test.go
+++ b/retry_test.go
@@ -141,10 +141,24 @@ func TestRandomDelay(t *testing.T) {
 		func() error { return errors.New("test") },
 		Attempts(3),
 		DelayType(RandomDelay),
-		MaxJitter(50 * time.Millisecond),
+		MaxJitter(50*time.Millisecond),
 	)
 	dur := time.Since(start)
 	assert.Error(t, err)
 	assert.True(t, dur > 2*time.Millisecond, "3 times random retry is longer then 2ms")
 	assert.True(t, dur < 100*time.Millisecond, "3 times random retry is shorter then 100ms")
+}
+
+func TestMaxDelay(t *testing.T) {
+	start := time.Now()
+	err := Do(
+		func() error { return errors.New("test") },
+		Attempts(5),
+		Delay(10*time.Millisecond),
+		MaxDelay(50*time.Millisecond),
+	)
+	dur := time.Since(start)
+	assert.Error(t, err)
+	assert.True(t, dur > 170*time.Millisecond, "5 times with maximum delay retry is longer than 70ms")
+	assert.True(t, dur < 200*time.Millisecond, "5 times with maximum delay retry is shorter than 200ms")
 }


### PR DESCRIPTION
This option ensures the delay between 2 retries can not exceed a specified duration