### PR TITLE
Shift to Go modules

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,3 +1,0 @@
-[[constraint]]
-  name = "github.com/stretchr/testify"
-  version = "1.1.4"

--- a/Makefile
+++ b/Makefile
@@ -1,37 +1,30 @@
 SOURCE_FILES?=$$(go list ./... | grep -v /vendor/)
 TEST_PATTERN?=.
 TEST_OPTIONS?=
-DEP?=$$(which dep)
 VERSION?=$$(cat VERSION)
 LINTER?=$$(which golangci-lint)
 LINTER_VERSION=1.15.0
 
 ifeq ($(OS),Windows_NT)
-	DEP_VERS=dep-windows-amd64
 	LINTER_FILE=golangci-lint-$(LINTER_VERSION)-windows-amd64.zip
 	LINTER_UNPACK= >| app.zip; unzip -j app.zip -d $$GOPATH/bin; rm app.zip
 else ifeq ($(OS), Darwin)
 	LINTER_FILE=golangci-lint-$(LINTER_VERSION)-darwin-amd64.tar.gz
 	LINTER_UNPACK= | tar xzf - -C $$GOPATH/bin --wildcards --strip 1 "**/golangci-lint"
 else
-	DEP_VERS=dep-linux-amd64
 	LINTER_FILE=golangci-lint-$(LINTER_VERSION)-linux-amd64.tar.gz
 	LINTER_UNPACK= | tar xzf - -C $$GOPATH/bin --wildcards --strip 1 "**/golangci-lint"
 endif
 
 setup:
-	go get -u github.com/pierrre/gotestcover
-	go get -u golang.org/x/tools/cmd/cover
-	go get -u github.com/robertkrimen/godocdown/godocdown
+	GO111MODULE=off go get -u github.com/pierrre/gotestcover
+	GO111MODULE=off go get -u golang.org/x/tools/cmd/cover
+	GO111MODULE=off go get -u github.com/robertkrimen/godocdown/godocdown
 	@if [ "$(LINTER)" = "" ]; then\
 		curl -L https://github.com/golangci/golangci-lint/releases/download/v$(LINTER_VERSION)/$(LINTER_FILE) $(LINTER_UNPACK) ;\
 		chmod +x $$GOPATH/bin/golangci-lint;\
 	fi
-	@if [ "$(DEP)" = "" ]; then\
-		curl -L https://github.com/golang/dep/releases/download/v0.3.1/$(DEP_VERS) >| $$GOPATH/bin/dep;\
-		chmod +x $$GOPATH/bin/dep;\
-	fi
-	dep ensure
+	go mod download
 
 generate: ## Generate README.md
 	godocdown >| README.md

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/avast/retry-go
+
+go 1.15
+
+require github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
closes #38 

- adds support for go modules
- updates Makefile to consume modules instead of using **dep**
- deletes **Gopkg.toml** as it is no longer relevant

This does not include any breaking changes in APIs and can be released as a minor version update.
