### PR TITLE
fix: Resolve go module import path

### DIFF
--- a/examples/custom_retry_function_test.go
+++ b/examples/custom_retry_function_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/avast/retry-go"
+	"github.com/avast/retry-go/v3"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/examples/delay_based_on_error_test.go
+++ b/examples/delay_based_on_error_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/avast/retry-go"
+	"github.com/avast/retry-go/v3"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/examples/http_get_test.go
+++ b/examples/http_get_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/avast/retry-go"
+	"github.com/avast/retry-go/v3"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/avast/retry-go
+module github.com/avast/retry-go/v3
 
 go 1.13
 


### PR DESCRIPTION
When using go modules with a version of v2+ and the project is in the root directory, the module name must be appended with the major version.

Fixes #45.