### PR TITLE
fix!: Context cancel add to errors

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -128,7 +128,11 @@ func Do(retryableFunc RetryableFunc, opts ...Option) error {
 			select {
 			case <-time.After(delayTime):
 			case <-config.context.Done():
-				return config.context.Err()
+				if config.lastErrorOnly {
+					return config.context.Err()
+				}
+				errorLog[n] = config.context.Err()
+				return errorLog
 			}
 
 		} else {


### PR DESCRIPTION
When using `retry.Context(ctx)` where the cancelled context stops the retry loop, add the context to the error log - Unless last error only is set.

This allows for consumers to access the errors that have occurred throughout the retry loop easily.

Technically this is a breaking change as previously it would return the error from the context by default, however now it will return a `retry.Error` by default.

Fixes #51 