### PR TITLE
Add support for contexts during infinite attempts

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -93,8 +93,11 @@ func Do(retryableFunc RetryableFunc, opts ...Option) error {
 			n++
 
 			config.onRetry(n, err)
-
-			<-time.After(delay(config, n, err))
+			select {
+			case <-time.After(delay(config, n, err)):
+			case <-config.context.Done():
+				return nil
+			}
 		}
 
 		return nil


### PR DESCRIPTION
Hello! I found that contexts aren't 100% respected if you set your retry attempts to be infinite. The `Do` function would only respect it if the context was closed before any retry attempts were made. This PR is to make contexts completely respected while maintaining the same API.