### PR TITLE
feat: add support for attempts based on error types

### DIFF
--- a/options.go
+++ b/options.go
@@ -23,16 +23,17 @@ type Timer interface {
 }
 
 type Config struct {
-	attempts      uint
-	delay         time.Duration
-	maxDelay      time.Duration
-	maxJitter     time.Duration
-	onRetry       OnRetryFunc
-	retryIf       RetryIfFunc
-	delayType     DelayTypeFunc
-	lastErrorOnly bool
-	context       context.Context
-	timer         Timer
+	attempts         uint
+	attemptsForError map[error]uint
+	delay            time.Duration
+	maxDelay         time.Duration
+	maxJitter        time.Duration
+	onRetry          OnRetryFunc
+	retryIf          RetryIfFunc
+	delayType        DelayTypeFunc
+	lastErrorOnly    bool
+	context          context.Context
+	timer            Timer
 
 	maxBackOffN uint
 }
@@ -55,6 +56,15 @@ func LastErrorOnly(lastErrorOnly bool) Option {
 func Attempts(attempts uint) Option {
 	return func(c *Config) {
 		c.attempts = attempts
+	}
+}
+
+// AttemptsForError sets count of retry in case execution results in given `err`
+// Retries for the given `err` are also counted against total retries.
+// The retry will stop if any of given retries is exhausted.
+func AttemptsForError(attempts uint, err error) Option {
+	return func(c *Config) {
+		c.attemptsForError[err] = attempts
 	}
 }
 

--- a/retry_test.go
+++ b/retry_test.go
@@ -110,6 +110,22 @@ func TestZeroAttemptsWithoutError(t *testing.T) {
 	assert.Equal(t, count, 1)
 }
 
+func TestAttemptsForError(t *testing.T) {
+	count := uint(0)
+	testErr := os.ErrInvalid
+	attemptsForTestError := uint(3)
+	err := Do(
+		func() error {
+			count++
+			return testErr
+		},
+		AttemptsForError(attemptsForTestError, testErr),
+		Attempts(5),
+	)
+	assert.Error(t, err)
+	assert.Equal(t, attemptsForTestError, count)
+}
+
 func TestDefaultSleep(t *testing.T) {
 	start := time.Now()
 	err := Do(


### PR DESCRIPTION
This commit adds a new option for configuring attempts based on error type.

Fixes: #48 

#### Testing

Also adds unit tests for the new option.