### PR TITLE
fix bug that overwrites last error when context is canceled

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -155,6 +155,7 @@ func Do(retryableFunc RetryableFunc, opts ...Option) error {
 				if config.lastErrorOnly {
 					return config.context.Err()
 				}
+				n++
 				errorLog[n] = config.context.Err()
 				return errorLog
 			}

--- a/retry_test.go
+++ b/retry_test.go
@@ -364,7 +364,8 @@ func TestContext(t *testing.T) {
 
 		expectedErrorFormat := `All attempts fail:
 #1: test
-#2: context canceled`
+#2: test
+#3: context canceled`
 		assert.Equal(t, expectedErrorFormat, err.Error(), "retry error format")
 		assert.Equal(t, 2, retrySum, "called at most once")
 	})


### PR DESCRIPTION
When using `retry.Context(ctx)` and context is canceled, `retry.Do` always overwrites last error as `context canceled`.
It is very dangerous if the last error overwritten by `retry.Do` should be recovered manually.