### PR TITLE
fix: return last non-nil value when unwrapping errors

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -243,7 +243,7 @@ when you need unwrap all erros, you should use `WrappedErrors()` instead
 added in version 4.2.0
 */
 func (e Error) Unwrap() error {
-	return e[len(e)-1]
+	return e[lenWithoutNil(e)-1]
 }
 
 func lenWithoutNil(e Error) (count int) {

--- a/retry_test.go
+++ b/retry_test.go
@@ -163,16 +163,17 @@ func TestLastErrorOnly(t *testing.T) {
 
 func TestUnrecoverableError(t *testing.T) {
 	attempts := 0
-	expectedErr := errors.New("error")
+	testErr := errors.New("error")
+	expectedErr := Error{testErr, nil}
 	err := Do(
 		func() error {
 			attempts++
-			return Unrecoverable(expectedErr)
+			return Unrecoverable(testErr)
 		},
 		Attempts(2),
-		LastErrorOnly(true),
 	)
 	assert.Equal(t, expectedErr, err)
+	assert.Equal(t, testErr, errors.Unwrap(err))
 	assert.Equal(t, 1, attempts, "unrecoverable error broke the loop")
 }
 


### PR DESCRIPTION
Fixes #78.