### PR TITLE
remove error log pre-allocation and add benchmark

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -114,72 +114,61 @@ func Do(retryableFunc RetryableFunc, opts ...Option) error {
 		return nil
 	}
 
-	var errorLog Error
-	if !config.lastErrorOnly {
-		errorLog = make(Error, config.attempts)
-	} else {
-		errorLog = make(Error, 1)
-	}
+	errorLog := Error{}
 
 	attemptsForError := make(map[error]uint, len(config.attemptsForError))
 	for err, attempts := range config.attemptsForError {
 		attemptsForError[err] = attempts
 	}
 
-	lastErrIndex := n
 	shouldRetry := true
 	for shouldRetry {
 		err := retryableFunc()
-
-		if err != nil {
-			errorLog[lastErrIndex] = unpackUnrecoverable(err)
-
-			if !config.retryIf(err) {
-				break
-			}
-
-			config.onRetry(n, err)
-
-			for errToCheck, attempts := range attemptsForError {
-				if errors.Is(err, errToCheck) {
-					attempts--
-					attemptsForError[errToCheck] = attempts
-					shouldRetry = shouldRetry && attempts > 0
-				}
-			}
-
-			// if this is last attempt - don't wait
-			if n == config.attempts-1 {
-				break
-			}
-
-			select {
-			case <-config.timer.After(delay(config, n, err)):
-			case <-config.context.Done():
-				if config.lastErrorOnly {
-					return config.context.Err()
-				}
-				n++
-				errorLog[n] = config.context.Err()
-				return errorLog[:lenWithoutNil(errorLog)]
-			}
-
-		} else {
+		if err == nil {
 			return nil
+		}
+
+		errorLog = append(errorLog, unpackUnrecoverable(err))
+
+		if !config.retryIf(err) {
+			break
+		}
+
+		config.onRetry(n, err)
+
+		for errToCheck, attempts := range attemptsForError {
+			if errors.Is(err, errToCheck) {
+				attempts--
+				attemptsForError[errToCheck] = attempts
+				shouldRetry = shouldRetry && attempts > 0
+			}
+		}
+
+		// if this is last attempt - don't wait
+		if n == config.attempts-1 {
+			break
+		}
+
+		select {
+		case <-config.timer.After(delay(config, n, err)):
+		case <-config.context.Done():
+			if config.lastErrorOnly {
+				return config.context.Err()
+			}
+			n++
+
+			return append(errorLog, config.context.Err())
 		}
 
 		n++
 		shouldRetry = shouldRetry && n < config.attempts
-
-		if !config.lastErrorOnly {
-			lastErrIndex = n
-		}
 	}
 
 	if config.lastErrorOnly {
-		return errorLog[lastErrIndex]
+		return errorLog.Unwrap()
 	}
-	return errorLog[:lenWithoutNil(errorLog)]
+
+	return errorLog
 }
 
 func newDefaultRetryConfig() *Config {
@@ -203,7 +192,7 @@ type Error []error
 // Error method return string representation of Error
 // It is an implementation of error interface
 func (e Error) Error() string {
-	logWithNumber := make([]string, lenWithoutNil(e))
+	logWithNumber := make([]string, len(e))
 	for i, l := range e {
 		if l != nil {
 			logWithNumber[i] = fmt.Sprintf("#%d: %s", i+1, l.Error())
@@ -247,17 +236,7 @@ When you need to unwrap all errors, you should use `WrappedErrors()` instead.
 Added in version 4.2.0.
 */
 func (e Error) Unwrap() error {
-	return e[lenWithoutNil(e)-1]
-}
-
-func lenWithoutNil(e Error) (count int) {
-	for _, v := range e {
-		if v != nil {
-			count++
-		}
-	}
-
-	return
+	return e[len(e)-1]
 }
 
 // WrappedErrors returns the list of errors that this Error is wrapping.

--- a/retry_test.go
+++ b/retry_test.go
@@ -503,3 +503,29 @@ func TestUnwrap(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, testError, errors.Unwrap(err))
 }
+
+func BenchmarkDo(b *testing.B) {
+	testError := errors.New("test error")
+
+	for i := 0; i < b.N; i++ {
+		Do(
+			func() error {
+				return testError
+			},
+			Attempts(10),
+			Delay(0),
+		)
+	}
+}
+
+func BenchmarkDoNoErrors(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Do(
+			func() error {
+				return nil
+			},
+			Attempts(10),
+			Delay(0),
+		)
+	}
+}

--- a/retry_test.go
+++ b/retry_test.go
@@ -526,7 +526,6 @@ func TestUnwrap(t *testing.T) {
 	assert.Equal(t, testError, errors.Unwrap(err))
 }
 
-
 func BenchmarkDo(b *testing.B) {
 	testError := errors.New("test error")
 


### PR DESCRIPTION
This PR removes `errorLog` slice pre-allocation with the assumption that most calls to `retry.Do` don't actually require retry. If this is wishful thinking, please let me know. Aside from the readability win, the benchmarks that I added show improvement around allocations & cpu cycles when no errors are encountered, as expected.


Here are the results of the benchmarks that this PR introduces:
```sh
$ go test -benchmem -run=^$ -bench ^BenchmarkDo github.com/avast/retry-go/v4 > old.txt

goos: darwin
goarch: amd64
pkg: github.com/avast/retry-go/v4
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkDo-16            	       3	 420393029 ns/op	    2197 B/op	      33 allocs/op
BenchmarkDoNoErrors-16    	 5136325	       230.7 ns/op	     368 B/op	       5 allocs/op
PASS
ok  	github.com/avast/retry-go/v4	4.331s
```

```sh
$ go test -benchmem -run=^$ -bench ^BenchmarkDo github.com/avast/retry-go/v4 > new.txt

goos: darwin
goarch: amd64
pkg: github.com/avast/retry-go/v4
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkDo-16            	       3	 372840109 ns/op	    2568 B/op	      38 allocs/op
BenchmarkDoNoErrors-16    	 7106366	       163.9 ns/op	     208 B/op	       4 allocs/op
PASS
ok  	github.com/avast/retry-go/v4	2.902s
```

```sh
$ benchstat old.txt new.txt

goos: darwin
goarch: amd64
pkg: github.com/avast/retry-go/v4
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
              │   old.txt    │                new.txt                │
              │    sec/op    │    sec/op     vs base                 │
Do-16           420.4m ± ∞ ¹   372.8m ± ∞ ¹        ~ (p=1.000 n=1) ²
DoNoErrors-16   230.7n ± ∞ ¹   163.9n ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean         311.4µ         247.2µ        -20.62%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

              │    old.txt    │                new.txt                 │
              │     B/op      │     B/op       vs base                 │
Do-16           2.146Ki ± ∞ ¹   2.508Ki ± ∞ ¹        ~ (p=1.000 n=1) ²
DoNoErrors-16     368.0 ± ∞ ¹     208.0 ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean           899.2           730.9        -18.72%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

              │   old.txt   │               new.txt               │
              │  allocs/op  │  allocs/op   vs base                │
Do-16           33.00 ± ∞ ¹   38.00 ± ∞ ¹       ~ (p=1.000 n=1) ²
DoNoErrors-16   5.000 ± ∞ ¹   4.000 ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean         12.85         12.33        -4.02%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05
```