### PR TITLE
Add DoWithData function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/avast/retry-go/v4
 
-go 1.13
+go 1.18
 
 require github.com/stretchr/testify v1.8.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/retry_test.go
+++ b/retry_test.go
@@ -11,14 +11,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDoAllFailed(t *testing.T) {
+func TestDoWithDataAllFailed(t *testing.T) {
 	var retrySum uint
-	err := Do(
-		func() error { return errors.New("test") },
+	v, err := DoWithData(
+		func() (int, error) { return 7, errors.New("test") },
 		OnRetry(func(n uint, err error) { retrySum += n }),
 		Delay(time.Nanosecond),
 	)
 	assert.Error(t, err)
+	assert.Equal(t, 0, v)
 
 	expectedErrorFormat := `All attempts fail:
 #1: test
@@ -44,7 +45,19 @@ func TestDoFirstOk(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, uint(0), retrySum, "no retry")
+}
 
+func TestDoWithDataFirstOk(t *testing.T) {
+	returnVal := 1
+
+	var retrySum uint
+	val, err := DoWithData(
+		func() (int, error) { return returnVal, nil },
+		OnRetry(func(n uint, err error) { retrySum += n }),
+	)
+	assert.NoError(t, err)
+	assert.Equal(t, returnVal, val)
+	assert.Equal(t, uint(0), retrySum, "no retry")
 }
 
 func TestRetryIf(t *testing.T) {


### PR DESCRIPTION
👋 I am not sure that you will consider this PR, but it is to add a `DoWithData` generic function that can also return data from a retry, not just an error. That is, it resolves #58. Of course, with this change I had to bump to Go 1.18.

If you think this is a useful feature, I could add some more tests and documentation.

I wasn't sure what to name this function so I borrowed the idea from https://pkg.go.dev/github.com/cenkalti/backoff/v4, which has a `RetryWithData` function which does a similar thing as this.

Thanks for the very useful library ❤️ 



