### PR TITLE
fix: markdown code block format

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,19 +355,17 @@ wait for a set duration for retries.
 
 example of augmenting time.After with a print statement
 
-type struct MyTimer {}
+    type struct MyTimer {}
 
     func (t *MyTimer) After(d time.Duration) <- chan time.Time {
         fmt.Print("Timer called!")
         return time.After(d)
     }
 
-retry.Do(
-
+    retry.Do(
         func() error { ... },
     	   retry.WithTimer(&MyTimer{})
-
-)
+    )
 
 #### type RetryIfFunc
 

--- a/options.go
+++ b/options.go
@@ -232,19 +232,17 @@ func Context(ctx context.Context) Option {
 //
 // example of augmenting time.After with a print statement
 //
-// type struct MyTimer {}
+//	type struct MyTimer {}
 //
 //	func (t *MyTimer) After(d time.Duration) <- chan time.Time {
 //	    fmt.Print("Timer called!")
 //	    return time.After(d)
 //	}
 //
-// retry.Do(
-//
+//	retry.Do(
 //	    func() error { ... },
 //		   retry.WithTimer(&MyTimer{})
-//
-// )
+//	)
 func WithTimer(t Timer) Option {
 	return func(c *Config) {
 		c.timer = t


### PR DESCRIPTION


| Before | After |
|:------|:-----|
| <img width="400" alt="スクリーンショット 2023-05-13 15 58 18" src="https://github.com/avast/retry-go/assets/5842353/63b80fed-a241-4791-9b72-b54806ecf866"> | <img width="400" alt="スクリーンショット 2023-05-13 15 58 35" src="https://github.com/avast/retry-go/assets/5842353/0d22c082-baa8-4d31-9865-c561b18b7cd5"> |

