### PR TITLE
fix potential panic in IsRecoverable

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -302,6 +302,13 @@ type unrecoverableError struct {
 	error
 }
 
+func (e unrecoverableError) Error() string {
+	if e.error == nil {
+		return "unrecoverable error"
+	}
+	return e.error.Error()
+}
+
 func (e unrecoverableError) Unwrap() error {
 	return e.error
 }


### PR DESCRIPTION
The way `unrecoverableError` wraps an error can lead to potential panics. In `IsRecoverable`, an `unrecoverableError` is passed to `errors.Is` without an embedded error. This is problematic because any error type that implements the `Is` interface and expects to be able to call `Error()` will trigger a panic due to the embedded error being `nil`.

To fix this, we can implement `Error()` on `unrecoverableError` and handle the case where the embedded error is nil.