### PR TITLE
Introduce UntilSucceeded option to improve readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@
 
 Simple library for retry mechanism
 
-slightly inspired by
+Slightly inspired by
 [Try::Tiny::Retry](https://metacpan.org/pod/Try::Tiny::Retry)
 
 # SYNOPSIS
 
-http get with retry:
+HTTP GET with retry:
 
     url := "http://example.com"
     var body []byte
@@ -31,17 +31,17 @@ http get with retry:
     		if err != nil {
     			return err
     		}
-
     		return nil
     	},
     )
+
     if err != nil {
     	// handle error
     }
 
     fmt.Println(string(body))
 
-http get with retry with data:
+HTTP GET with retry with data:
 
     url := "http://example.com"
 
@@ -60,13 +60,14 @@ http get with retry with data:
     		return body, nil
     	},
     )
+
     if err != nil {
     	// handle error
     }
 
     fmt.Println(string(body))
 
-[next examples](https://github.com/avast/retry-go/tree/master/examples)
+[More examples](https://github.com/avast/retry-go/tree/master/examples)
 
 # SEE ALSO
 
@@ -241,10 +242,10 @@ used with that library.
 #### type OnRetryFunc
 
 ```go
-type OnRetryFunc func(n uint, err error)
+type OnRetryFunc func(attempt uint, err error)
 ```
 
-Function signature of OnRetry function n = count of attempts
+Function signature of OnRetry function
 
 #### type Option
 
@@ -366,7 +367,7 @@ skip retry if special error example:
     			return false
     		}
     		return true
-    	}),
+    	})
     )
 
 By default RetryIf stops execution if the error is wrapped using
@@ -377,6 +378,14 @@ By default RetryIf stops execution if the error is wrapped using
     		return retry.Unrecoverable(errors.New("special error"))
     	}
     )
+
+#### func  UntilSucceeded
+
+```go
+func UntilSucceeded() Option
+```
+UntilSucceeded will retry until the retried function succeeds. Equivalent to
+setting Attempts(0).
 
 #### func  WithTimer
 

--- a/options.go
+++ b/options.go
@@ -11,8 +11,7 @@ import (
 type RetryIfFunc func(error) bool
 
 // Function signature of OnRetry function
-// n = count of attempts
-type OnRetryFunc func(n uint, err error)
+type OnRetryFunc func(attempt uint, err error)
 
 // DelayTypeFunc is called to return the next delay to wait after the retriable function fails on `err` after `n` attempts.
 type DelayTypeFunc func(n uint, err error, config *Config) time.Duration
@@ -57,6 +56,13 @@ func LastErrorOnly(lastErrorOnly bool) Option {
 func Attempts(attempts uint) Option {
 	return func(c *Config) {
 		c.attempts = attempts
+	}
+}
+
+// UntilSucceeded will retry until the retried function succeeds. Equivalent to setting Attempts(0).
+func UntilSucceeded() Option {
+	return func(c *Config) {
+		c.attempts = 0
 	}
 }
 

--- a/retry.go
+++ b/retry.go
@@ -1,11 +1,11 @@
 /*
 Simple library for retry mechanism
 
-slightly inspired by [Try::Tiny::Retry](https://metacpan.org/pod/Try::Tiny::Retry)
+Slightly inspired by [Try::Tiny::Retry](https://metacpan.org/pod/Try::Tiny::Retry)
 
 # SYNOPSIS
 
-http get with retry:
+HTTP GET with retry:
 
 	url := "http://example.com"
 	var body []byte
@@ -21,17 +21,17 @@ http get with retry:
 			if err != nil {
 				return err
 			}
-
 			return nil
 		},
 	)
+
 	if err != nil {
 		// handle error
 	}
 
 	fmt.Println(string(body))
 
-http get with retry with data:
+HTTP GET with retry with data:
 
 	url := "http://example.com"
 
@@ -50,13 +50,14 @@ http get with retry with data:
 			return body, nil
 		},
 	)
+
 	if err != nil {
 		// handle error
 	}
 
 	fmt.Println(string(body))
 
-[next examples](https://github.com/avast/retry-go/tree/master/examples)
+[More examples](https://github.com/avast/retry-go/tree/master/examples)
 
 # SEE ALSO
 


### PR DESCRIPTION
Hello, IMHO, the `Attemps(0)` approach leads to surprises as it has no clear meaning. 

So with this PR, instead of
```go
Attempts(0)
```
You should also be able to write
```go
UntilSucceeded()
```

And the code becomes much more clear to read and understand.

Attemps(0) will continue to work, but I think it should be removed in another major version, in favor of a more intuitive API.

Also, I've made small changes in docs.