### PR TITLE
support context cancel cause

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/avast/retry-go/v4
 
-go 1.18
+go 1.20
 
 require github.com/stretchr/testify v1.10.0
 

--- a/retry.go
+++ b/retry.go
@@ -132,7 +132,7 @@ func DoWithData[T any](retryableFunc RetryableFuncWithData[T], opts ...Option) (
 		opt(config)
 	}
 
-	if err := config.context.Err(); err != nil {
+	if err := context.Cause(config.context); err != nil {
 		return emptyT, err
 	}
 
@@ -161,9 +161,9 @@ func DoWithData[T any](retryableFunc RetryableFuncWithData[T], opts ...Option) (
 			case <-config.timer.After(delay(config, n, err)):
 			case <-config.context.Done():
 				if config.wrapContextErrorWithLastError {
-					return emptyT, Error{config.context.Err(), lastErr}
+					return emptyT, Error{context.Cause(config.context), lastErr}
 				}
-				return emptyT, config.context.Err()
+				return emptyT, context.Cause(config.context)
 			}
 		}
 	}
@@ -207,10 +207,10 @@ func DoWithData[T any](retryableFunc RetryableFuncWithData[T], opts ...Option) (
 		case <-config.timer.After(delay(config, n, err)):
 		case <-config.context.Done():
 			if config.lastErrorOnly {
-				return emptyT, config.context.Err()
+				return emptyT, context.Cause(config.context)
 			}
 
-			return emptyT, append(errorLog, config.context.Err())
+			return emptyT, append(errorLog, context.Cause(config.context))
 		}
 
 		shouldRetry = shouldRetry && n < config.attempts


### PR DESCRIPTION
When consumers of `retry-go` use the context `Cause` feature (introduced in go 1.20), the Cause error is not being extracted.