### PR TITLE
No delay after final retry on max attempts

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -175,8 +175,8 @@ func DoWithData[T any](retryableFunc RetryableFuncWithData[T], opts ...Option) (
 		attemptsForError[err] = attempts
 	}
 
-	shouldRetry := true
-	for shouldRetry {
+shouldRetry:
+	for {
 		t, err := retryableFunc()
 		if err == nil {
 			return t, nil
@@ -194,13 +194,15 @@ func DoWithData[T any](retryableFunc RetryableFuncWithData[T], opts ...Option) (
 			if errors.Is(err, errToCheck) {
 				attempts--
 				attemptsForError[errToCheck] = attempts
-				shouldRetry = shouldRetry && attempts > 0
+				if attempts <= 0 {
+					break shouldRetry
+				}
 			}
 		}
 
 		// if this is last attempt - don't wait
 		if n == config.attempts-1 {
-			break
+			break shouldRetry
 		}
 		n++
 		select {
@@ -212,8 +214,6 @@ func DoWithData[T any](retryableFunc RetryableFuncWithData[T], opts ...Option) (
 
 			return emptyT, append(errorLog, context.Cause(config.context))
 		}
-
-		shouldRetry = shouldRetry && n < config.attempts
 	}
 
 	if config.lastErrorOnly {


### PR DESCRIPTION
This MR addresses an issue where a delay is still applied after the final attempt, even when the maximum number of attempts for a specific error type has been reached.

**Problem:**
When using the `retry.AttemptsForError()` option to define a custom attempt limit for a specific error type, the retry logic still applies the configured delay after the final permitted attempt for that error. This results in unnecessary wait time and inconsistent behavior.

**Steps to Reproduce:**

```go
pacakge main

var count uint64 = 0
var currentTime = time.Now()

type TestError struct {
}

func (TestError) Error() string {
	return ""
}

func action() error {
	count += 1
	fmt.Printf("Attempts: %v; Time: %v\n", count, time.Since(currentTime).Round(time.Second))
	currentTime = time.Now()

	return TestError{}
}

func main() {
	_ = retry.Do(action,
		retry.Attempts(3),
		retry.Delay(2*time.Second),
		retry.DelayType(retry.FixedDelay),
		retry.AttemptsForError(2, TestError{}),
		retry.LastErrorOnly(true),
		retry.Context(context.Background()))

	fmt.Printf("End Time: %v\n", time.Since(currentTime).Round(time.Second))
}
```

**Observed Output:**

```
Attempts: 1; Time: 0s
Attempts: 2; Time: 2s
End Time: 2s
```

**Expected Output:**

```
Attempts: 1; Time: 0s
Attempts: 2; Time: 2s
End Time: 0s
```