### PR TITLE
BackOffDelay multiplies attempts from zero

### DIFF
--- a/options.go
+++ b/options.go
@@ -124,6 +124,8 @@ func BackOffDelay(n uint, _ error, config *Config) time.Duration {
 		config.maxBackOffN = max - uint(math.Floor(math.Log2(float64(config.delay))))
 	}
 
+	n--
+
 	if n > config.maxBackOffN {
 		n = config.maxBackOffN
 	}

--- a/retry_test.go
+++ b/retry_test.go
@@ -294,7 +294,7 @@ func TestBackOffDelay(t *testing.T) {
 			delay:         -1,
 			expectedMaxN:  62,
 			n:             2,
-			expectedDelay: 4,
+			expectedDelay: 2,
 		},
 		{
 			label:         "zero-delay",
@@ -309,6 +309,13 @@ func TestBackOffDelay(t *testing.T) {
 			expectedMaxN:  33,
 			n:             62,
 			expectedDelay: time.Second << 33,
+		},
+		{
+			label:         "one-second-n",
+			delay:         time.Second,
+			expectedMaxN:  33,
+			n:             1,
+			expectedDelay: time.Second,
 		},
 	} {
 		t.Run(
@@ -489,7 +496,7 @@ func TestContext(t *testing.T) {
 	})
 
 	t.Run("timed out on retry infinte attempts - wraps context error with last retried function error", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*500)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*200)
 		defer cancel()
 
 		retrySum := 0


### PR DESCRIPTION
This MR addresses an [issue/127](https://github.com/avast/retry-go/issues/127) where the BackOffDelay function incorrectly multiplies the delay duration, not taking into account that the attempt count starts from 1, thus the first delay is initially multiplied twice. In the description for this function, what should increase with the sequence. But in fact, it's a passion from the very first call.

**Steps to Reproduce:**

```go
package main

import (
	"context"
	"errors"
	"fmt"
	"time"

	"github.com/avast/retry-go/v4"
)

var count uint64 = 6
var currentTime = time.Now()

func action() error {
	fmt.Printf("Time: %v\n", time.Since(currentTime).Round(time.Second))
	currentTime = time.Now()
	if count == 0 {
		return nil
	}
	count -= 1
	return errors.New("something went wrong")
}

func main() {
	_ = retry.Do(action,
		retry.Attempts(3),
		retry.Delay(2*time.Second),
		retry.DelayType(retry.BackOffDelay),
		retry.LastErrorOnly(true),
		retry.Context(context.Background()))
}

```

**Observed Output:**

```
Time: 0s
Time: 4s
Time: 8s
```

**Expected Output:**

```
Time: 0s
Time: 2s
Time: 4s
```