### PR TITLE
Fix: Check Attempts For Error even when Attempts is zero

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -136,38 +136,6 @@ func DoWithData[T any](retryableFunc RetryableFuncWithData[T], opts ...Option) (
 		return emptyT, err
 	}
 
-	// Setting attempts to 0 means we'll retry until we succeed
-	var lastErr error
-	if config.attempts == 0 {
-		for {
-			t, err := retryableFunc()
-			if err == nil {
-				return t, nil
-			}
-
-			if !IsRecoverable(err) {
-				return emptyT, err
-			}
-
-			if !config.retryIf(err) {
-				return emptyT, err
-			}
-
-			lastErr = err
-
-			config.onRetry(n, err)
-			n++
-			select {
-			case <-config.timer.After(delay(config, n, err)):
-			case <-config.context.Done():
-				if config.wrapContextErrorWithLastError {
-					return emptyT, Error{context.Cause(config.context), lastErr}
-				}
-				return emptyT, context.Cause(config.context)
-			}
-		}
-	}
-
 	errorLog := Error{}
 
 	attemptsForError := make(map[error]uint, len(config.attemptsForError))
@@ -184,6 +152,10 @@ func DoWithData[T any](retryableFunc RetryableFuncWithData[T], opts ...Option) (
 
 		errorLog = append(errorLog, unpackUnrecoverable(err))
 
+		if !IsRecoverable(err) {
+			break
+		}
+
 		if !config.retryIf(err) {
 			break
 		}
@@ -198,8 +170,9 @@ func DoWithData[T any](retryableFunc RetryableFuncWithData[T], opts ...Option) (
 			}
 		}
 
+		// Setting attempts to 0 means we'll retry until we succeed
 		// if this is last attempt - don't wait
-		if n == config.attempts-1 {
+		if config.attempts != 0 && n == config.attempts-1 {
 			break
 		}
 		n++


### PR DESCRIPTION
This MR fixes a logic issue where AttemptsForError was ignored when the global Attempts value was set to 0. Since version 4.3.0, the retry library introduced AttemptsForError to allow fine-grained retry limits per error type. However, this mechanism was silently bypassed if retry.Attempts(0) was set, causing unexpected behavior and making debugging difficult.

Additionally, the logic for calling Is Recoverable was moved into the main retry loop to ensure it is properly respected for all configured attempts and error types.

Changes:

Apply AttemptsForError even if retry.Attempts(0) is used

Move IsRecoverable logic into the core retry loop to ensure it is evaluated consistently

Backward Compatibility:
This change makes retry behavior more consistent and does not break existing configurations unless users relied on the undocumented behavior of Attempts(0) disabling all retry logic.